### PR TITLE
add support for legacy projects, fix migration failure

### DIFF
--- a/source/database/migrations/2024_08_02_000000_create_accruals_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_accruals_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreateAccrualsTable extends Migration
 {
@@ -13,10 +14,13 @@ class CreateAccrualsTable extends Migration
      */
     public function up()
     {
-        Schema::create('earmark_accrual', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->timestamps();
-        });
+        //fixes the issue of legacy databases already having the
+        if (!Schema::hasTable('earmark_accrual')) {
+            Schema::create('earmark_accrual', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->timestamps();
+            });
+        }
     }
 
     /**
@@ -26,6 +30,9 @@ class CreateAccrualsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('accruals');
+        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_27_062621_create_accruals_table')->first();
+        if(!$legacyMigration){
+            Schema::dropIfExists('earmark_accrual');
+        }
     }
 }

--- a/source/database/migrations/2024_08_02_000000_create_accruals_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_accruals_table.php
@@ -30,9 +30,6 @@ class CreateAccrualsTable extends Migration
      */
     public function down()
     {
-        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_27_062621_create_accruals_table')->first();
-        if(!$legacyMigration){
-            Schema::dropIfExists('earmark_accrual');
-        }
+        Schema::dropIfExists('earmark_accrual');
     }
 }

--- a/source/database/migrations/2024_08_02_000000_create_earmark_hold_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_earmark_hold_table.php
@@ -37,9 +37,6 @@ class CreateEarmarkHoldTable extends Migration
      */
     public function down()
     {
-        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_22_090330_create_earmark_hold_table')->first();
-        if(!$legacyMigration) {
-            Schema::dropIfExists('earmark_hold');
-        }
+        Schema::dropIfExists('earmark_hold');
     }
 }

--- a/source/database/migrations/2024_08_02_000000_create_earmark_hold_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_earmark_hold_table.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class CreateEarmarkHoldTable extends Migration
 {
@@ -13,15 +14,17 @@ class CreateEarmarkHoldTable extends Migration
      */
     public function up()
     {
-        Schema::create('earmark_hold', function (Blueprint $table) {
-            $table->increments('id');
-            $table->integer(config('earmark.columns.digit'));
-            $table->string(config('earmark.columns.group'))->nullable();
-            $table->timestamps();
+        if (!Schema::hasTable('earmark_hold')) {
+            Schema::create('earmark_hold', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer(config('earmark.columns.digit'));
+                $table->string(config('earmark.columns.group'))->nullable();
+                $table->timestamps();
 
-            $table->index(config('earmark.columns.digit'));
-            $table->index(config('earmark.columns.group'));
-        });
+                $table->index(config('earmark.columns.digit'));
+                $table->index(config('earmark.columns.group'));
+            });
+        }
 
         // Poing\Earmark\Models\EarMark::max('digit')
         // Poing\Earmark\Models\EarMark::where('type','alpha')->max('digit')
@@ -34,6 +37,9 @@ class CreateEarmarkHoldTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('earmark_hold');
+        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_22_090330_create_earmark_hold_table')->first();
+        if(!$legacyMigration) {
+            Schema::dropIfExists('earmark_hold');
+        }
     }
 }

--- a/source/database/migrations/2024_08_02_000000_create_earmark_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_earmark_table.php
@@ -13,15 +13,17 @@ class CreateEarmarkTable extends Migration
      */
     public function up()
     {
-        Schema::create('earmark', function (Blueprint $table) {
-            $table->increments('id');
-            $table->integer(config('earmark.columns.digit'));
-            $table->string(config('earmark.columns.group'))->nullable();
-            $table->timestamps();
+        if (!Schema::hasTable('earmark')) {
+            Schema::create('earmark', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer(config('earmark.columns.digit'));
+                $table->string(config('earmark.columns.group'))->nullable();
+                $table->timestamps();
 
-            $table->index(config('earmark.columns.digit'));
-            $table->index(config('earmark.columns.group'));
-        });
+                $table->index(config('earmark.columns.digit'));
+                $table->index(config('earmark.columns.group'));
+            });
+        }
 
         // Poing\Earmark\Models\EarMark::max('digit')
         // Poing\Earmark\Models\EarMark::where('type','alpha')->max('digit')
@@ -34,6 +36,9 @@ class CreateEarmarkTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('earmark');
+        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_22_090330_create_earmark_table')->first();
+        if(!$legacyMigration) {
+            Schema::dropIfExists('earmark');
+        }
     }
 }

--- a/source/database/migrations/2024_08_02_000000_create_earmark_table.php
+++ b/source/database/migrations/2024_08_02_000000_create_earmark_table.php
@@ -36,9 +36,6 @@ class CreateEarmarkTable extends Migration
      */
     public function down()
     {
-        $legacyMigration = DB::table('migrations')->where('migration', '2019_05_22_090330_create_earmark_table')->first();
-        if(!$legacyMigration) {
-            Schema::dropIfExists('earmark');
-        }
+        Schema::dropIfExists('earmark');
     }
 }


### PR DESCRIPTION
Fixes the migration error for legacy projects - Duplicate table: 7 ERROR:  relation \"earmark_accrual\" already exists at.
Legacy projects have tables already existing and migration is trying to create them again. Also revert should not destroy the existing data  in case of legacy migration exists.